### PR TITLE
auto-resolve

### DIFF
--- a/modaic/hub.py
+++ b/modaic/hub.py
@@ -179,7 +179,7 @@ def sync_and_push(
     if module._from_auto:
         sync_dir = sync_dir_from(module._source)
     else:
-        sync_dir = create_sync_dir(repo_path, with_code=with_code)
+        sync_dir = create_sync_dir(repo_path, module, with_code=with_code)
     save_auto_json = with_code and not module._from_auto
     is_probe = hasattr(module, "_is_probe") and module._is_probe
     if is_probe:
@@ -630,7 +630,7 @@ def _update_staging_dir(
         copy_update_program_dir(repo_dir, repo_path, with_code=with_code)
     elif not source and not sys.platform.startswith("win"):
         # Linux/Unix - no source provided: Sync code from workspace into repo_dir (uses symlinks)
-        sync_dir = create_sync_dir(repo_path, with_code=with_code)
+        sync_dir = create_sync_dir(repo_path, module, with_code=with_code)
         _sync_repo(sync_dir, repo_dir)
 
     # save auto_classes.json only if we are saving the code and not using a source repo

--- a/tests/artifacts/test_repos/nested_repo/LICENSE
+++ b/tests/artifacts/test_repos/nested_repo/LICENSE
@@ -1,0 +1,1 @@
+not program's license

--- a/tests/artifacts/test_repos/nested_repo/README.md
+++ b/tests/artifacts/test_repos/nested_repo/README.md
@@ -1,0 +1,1 @@
+not the program's readme

--- a/tests/artifacts/test_repos/nested_repo/program/LICENSE
+++ b/tests/artifacts/test_repos/nested_repo/program/LICENSE
@@ -1,0 +1,1 @@
+program's actual license

--- a/tests/artifacts/test_repos/nested_repo/program/README.md
+++ b/tests/artifacts/test_repos/nested_repo/program/README.md
@@ -1,0 +1,1 @@
+program's actual readme

--- a/tests/artifacts/test_repos/nested_repo/pyproject.toml
+++ b/tests/artifacts/test_repos/nested_repo/pyproject.toml
@@ -11,3 +11,6 @@ dependencies = [
 
 [tool.uv.sources]
 modaic = { workspace = true }
+
+[tool.modaic]
+auto-resolve = ["readme", "license"]

--- a/tests/artifacts/test_repos/nested_repo_2/LICENSE
+++ b/tests/artifacts/test_repos/nested_repo_2/LICENSE
@@ -1,0 +1,1 @@
+program's actual license

--- a/tests/artifacts/test_repos/nested_repo_2/pyproject.toml
+++ b/tests/artifacts/test_repos/nested_repo_2/pyproject.toml
@@ -15,3 +15,6 @@ modaic = { workspace = true }
 [tool.modaic.include]
 dependencies = ["praw", "sagemaker"]
 files = ["program/utils/unused_but_included.py", "unused_but_included_folder"]
+
+[tool.modaic]
+auto-resolve = ["license"]

--- a/tests/artifacts/test_repos/nested_repo_3/pyproject.toml
+++ b/tests/artifacts/test_repos/nested_repo_3/pyproject.toml
@@ -19,3 +19,6 @@ modaic = { workspace = true }
 
 [tool.modaic.include]
 files = ["program/utils/unused_but_included.py", "program/tools/unused_but_included2.py"]
+
+[tool.modaic]
+auto-resolve = ["readme"]

--- a/tests/artifacts/test_repos/simple_repo_with_compile/pyproject.toml
+++ b/tests/artifacts/test_repos/simple_repo_with_compile/pyproject.toml
@@ -18,3 +18,6 @@ files = ["include_me_too.txt"]
 
 [tool.modaic.exclude]
 dependencies = ["praw", "sagemaker"]
+
+[tool.modaic]
+auto-resolve = ["readme"]

--- a/tests/test_auto.py
+++ b/tests/test_auto.py
@@ -84,7 +84,7 @@ FolderLayout = dict[str, Union[str, "FolderLayout"]] | list[Union[str, "FolderLa
 
 
 def assert_expected_files(cache_dir: Path, extra_expected_files: FolderLayout):
-    default_expected = ["program.json", "auto_classes.json", "config.json", "pyproject.toml", "README.md", ".git"]
+    default_expected = ["program.json", "auto_classes.json", "config.json", "pyproject.toml", ".git"]
     if isinstance(extra_expected_files, list):
         expected = extra_expected_files + default_expected
     elif isinstance(extra_expected_files, dict):
@@ -223,7 +223,7 @@ def test_simple_repo_no_token(monkeypatch: pytest.MonkeyPatch):
     assert program.runtime_param == "Hello"
 
 
-simple_repo_with_compile_extra_files = [{"program": ["program.py", "mod.py"]}, "compile.py", "include_me_too.txt"]
+simple_repo_with_compile_extra_files = [{"program": ["program.py", "mod.py"]}, "compile.py", "include_me_too.txt", "README.md"]
 
 
 def test_simple_repo_with_compile():
@@ -243,7 +243,7 @@ def test_simple_repo_with_compile():
     assert os.path.exists(cache_dir / "program" / "mod.py")
     assert os.path.exists(cache_dir / "pyproject.toml")
     assert os.path.exists(cache_dir / "include_me_too.txt")
-    extra_files = [{"program": ["program.py", "mod.py"]}, "compile.py", "include_me_too.txt"]
+    extra_files = [{"program": ["program.py", "mod.py"]}, "compile.py", "include_me_too.txt", "README.md"]
     assert_expected_files(cache_dir, extra_files)
     assert_dependencies(cache_dir, ["dspy", "modaic"])
     clean_modaic_cache()
@@ -270,18 +270,22 @@ def test_simple_repo_with_compile():
     # TODO: test third party deps installation
 
 
-nested_repo_extra_files = {
-    "program": [
-        {
-            "tools": {"google": "google_search.py", "jira": "jira_api_tools.py"},
-            "utils": ["second_degree_import.py", "used.py"],
-        },
-        "program.py",
-        "compile.py",
-        "config.py",
-        "retriever.py",
-    ]
-}
+nested_repo_extra_files = [
+    {
+        "program": [
+            {
+                "tools": {"google": "google_search.py", "jira": "jira_api_tools.py"},
+                "utils": ["second_degree_import.py", "used.py"],
+            },
+            "program.py",
+            "compile.py",
+            "config.py",
+            "retriever.py",
+        ]
+    },
+    "README.md",
+    "LICENSE",
+]
 nested_repo_2_extra_files = [
     {
         "program": [
@@ -300,18 +304,22 @@ nested_repo_2_extra_files = [
     },
     {"unused_but_included_folder": ["folder_content1.py", "folder_content2.txt"]},
     "compile.py",
+    "LICENSE",
 ]
-nested_repo_3_extra_files = {
-    "program": [
-        {
-            "tools": [{"google": "google_search.py", "jira": "jira_api_tools.py"}, "unused_but_included2.py"],
-            "utils": ["second_degree_import.py", "unused_but_included.py", "used.py"],
-        },
-        "program.py",
-        "config.py",
-        "retriever.py",
-    ],
-}
+nested_repo_3_extra_files = [
+    {
+        "program": [
+            {
+                "tools": [{"google": "google_search.py", "jira": "jira_api_tools.py"}, "unused_but_included2.py"],
+                "utils": ["second_degree_import.py", "unused_but_included.py", "used.py"],
+            },
+            "program.py",
+            "config.py",
+            "retriever.py",
+        ],
+    },
+    "README.md",
+]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_precompiled.py
+++ b/tests/test_precompiled.py
@@ -275,11 +275,8 @@ def test_precompiled_program_hub(hub_repo: str, branch: str):
 
     assert os.path.exists(staging_dir / "config.json")
     assert os.path.exists(staging_dir / "program.json")
-    assert os.path.exists(staging_dir / "README.md")
-    assert os.path.exists(staging_dir / "LICENSE")
-    assert os.path.exists(staging_dir / "CONTRIBUTING.md")
     assert os.path.exists(staging_dir / ".git")
-    assert len(os.listdir(staging_dir)) == 6
+    assert len(os.listdir(staging_dir)) == 3
     loaded_program = ExampleProgram.from_precompiled(
         hub_repo, runtime_param="wassuh", config={"lm": "openai/gpt-4o"}, rev=branch
     )
@@ -298,11 +295,8 @@ def test_precompiled_program_hub(hub_repo: str, branch: str):
     )
     assert os.path.exists(repo_dir / "config.json")
     assert os.path.exists(repo_dir / "program.json")
-    assert os.path.exists(repo_dir / "README.md")
-    assert os.path.exists(repo_dir / "LICENSE")
-    assert os.path.exists(repo_dir / "CONTRIBUTING.md")
     assert os.path.exists(repo_dir / ".git")
-    assert len(os.listdir(repo_dir)) == 6
+    assert len(os.listdir(repo_dir)) == 3
     assert loaded_program2.runtime_param == "wassuh2"
     assert loaded_program2.config.number == 2
     assert loaded_program2.config.lm == "openai/gpt-4o"
@@ -332,11 +326,8 @@ def test_precompiled_program_hub(hub_repo: str, branch: str):
 
     assert os.path.exists(repo_dir / "config.json")
     assert os.path.exists(repo_dir / "program.json")
-    assert os.path.exists(repo_dir / "README.md")
-    assert os.path.exists(repo_dir / "LICENSE")
-    assert os.path.exists(repo_dir / "CONTRIBUTING.md")
     assert os.path.exists(repo_dir / ".git")
-    assert len(os.listdir(repo_dir)) == 6
+    assert len(os.listdir(repo_dir)) == 3
     assert loaded_program3.runtime_param == "wassuh4"
     assert loaded_program3.config.output_type == "bool"
     assert loaded_program3.config.lm == "openai/gpt-4o"
@@ -353,11 +344,8 @@ def test_precompiled_retriever_hub(hub_repo: str, branch: str):
     staging_dir = STAGING_DIR / hub_repo
     repo_dir = Path(MODAIC_HUB_CACHE) / hub_repo / branch
     assert os.path.exists(staging_dir / "config.json")
-    assert os.path.exists(staging_dir / "README.md")
-    assert os.path.exists(staging_dir / "LICENSE")
-    assert os.path.exists(staging_dir / "CONTRIBUTING.md")
     assert os.path.exists(staging_dir / ".git")
-    assert len(os.listdir(staging_dir)) == 5
+    assert len(os.listdir(staging_dir)) == 2
     loaded_retriever = ExampleRetriever.from_precompiled(
         hub_repo, needed_param="Goodbye", config={"num_fetch": 20}, rev=branch
     )
@@ -371,11 +359,8 @@ def test_precompiled_retriever_hub(hub_repo: str, branch: str):
     # Push changes just to branch (num_fetch = 20)
     loaded_retriever.push_to_hub(hub_repo, with_code=False, branch=branch)
     assert os.path.exists(repo_dir / "config.json")
-    assert os.path.exists(repo_dir / "README.md")
-    assert os.path.exists(repo_dir / "LICENSE")
-    assert os.path.exists(repo_dir / "CONTRIBUTING.md")
     assert os.path.exists(repo_dir / ".git")
-    assert len(os.listdir(repo_dir)) == 5
+    assert len(os.listdir(repo_dir)) == 2
 
     # Check changes to branch went through (num_fetch = 20)
     loaded_retriever2 = ExampleRetriever.from_precompiled(
@@ -406,11 +391,8 @@ def test_precompiled_retriever_hub(hub_repo: str, branch: str):
     # test with local cache removed + (num_fetch = 20, lm = openai/gpt-4o)
     loaded_retriever2.push_to_hub(hub_repo, with_code=False, branch=branch)
     assert os.path.exists(repo_dir / "config.json")
-    assert os.path.exists(repo_dir / "README.md")
-    assert os.path.exists(repo_dir / "LICENSE")
-    assert os.path.exists(repo_dir / "CONTRIBUTING.md")
     assert os.path.exists(repo_dir / ".git")
-    assert len(os.listdir(repo_dir)) == 5
+    assert len(os.listdir(repo_dir)) == 2
 
     smart_rmtree(repo_dir.parent)
     loaded_retriever3 = ExampleRetriever.from_precompiled(
@@ -437,11 +419,8 @@ def test_precompiled_program_with_retriever_hub(hub_repo: str, branch: str):
     repo_dir = Path(MODAIC_HUB_CACHE) / hub_repo / branch
     assert os.path.exists(staging_dir / "config.json")
     assert os.path.exists(staging_dir / "program.json")
-    assert os.path.exists(staging_dir / "README.md")
     assert os.path.exists(staging_dir / ".git")
-    assert os.path.exists(staging_dir / "LICENSE")
-    assert os.path.exists(staging_dir / "CONTRIBUTING.md")
-    assert len(os.listdir(staging_dir)) == 6
+    assert len(os.listdir(staging_dir)) == 3
 
     config = {"num_fetch": 20}
     loaded_retriever = ExampleRetriever.from_precompiled(hub_repo, needed_param="Goodbye", config=config, rev=branch)
@@ -462,11 +441,8 @@ def test_precompiled_program_with_retriever_hub(hub_repo: str, branch: str):
     loaded_program.push_to_hub(hub_repo, with_code=False, branch=branch)
     assert os.path.exists(repo_dir / "config.json")
     assert os.path.exists(repo_dir / "program.json")
-    assert os.path.exists(repo_dir / "README.md")
     assert os.path.exists(repo_dir / ".git")
-    assert os.path.exists(repo_dir / "LICENSE")
-    assert os.path.exists(repo_dir / "CONTRIBUTING.md")
-    assert len(os.listdir(repo_dir)) == 6
+    assert len(os.listdir(repo_dir)) == 3
 
     # Check changes to branch went through
     config = {"lm": "openai/gpt-4o"}
@@ -498,11 +474,8 @@ def test_precompiled_program_with_retriever_hub(hub_repo: str, branch: str):
     loaded_program2.push_to_hub(hub_repo, with_code=False, branch=branch)
     assert os.path.exists(repo_dir / "config.json")
     assert os.path.exists(repo_dir / "program.json")
-    assert os.path.exists(repo_dir / "README.md")
     assert os.path.exists(repo_dir / ".git")
-    assert os.path.exists(repo_dir / "LICENSE")
-    assert os.path.exists(repo_dir / "CONTRIBUTING.md")
-    assert len(os.listdir(repo_dir)) == 6
+    assert len(os.listdir(repo_dir)) == 3
 
     smart_rmtree(repo_dir.parent)
     config = {"clients": {"openai": ["sama3"]}}
@@ -523,11 +496,8 @@ def test_precompiled_no_token_hub(hub_repo: str, monkeypatch: pytest.MonkeyPatch
     )
     staging_dir = STAGING_DIR / hub_repo
     assert os.path.exists(staging_dir / "config.json")
-    assert os.path.exists(staging_dir / "README.md")
-    assert os.path.exists(staging_dir / "LICENSE")
-    assert os.path.exists(staging_dir / "CONTRIBUTING.md")
     assert os.path.exists(staging_dir / ".git")
-    assert len(os.listdir(staging_dir)) == 5
+    assert len(os.listdir(staging_dir)) == 2
 
     from modaic import hub
 
@@ -633,11 +603,8 @@ def test_no_config_hub(hub_repo: str, ProgramCls: Type[PrecompiledProgram]):  # 
 
     assert os.path.exists(staging_dir / "config.json")
     assert os.path.exists(staging_dir / "program.json")
-    assert os.path.exists(staging_dir / "README.md")
     assert os.path.exists(staging_dir / ".git")
-    assert os.path.exists(staging_dir / "LICENSE")
-    assert os.path.exists(staging_dir / "CONTRIBUTING.md")
-    assert len(os.listdir(staging_dir)) == 6
+    assert len(os.listdir(staging_dir)) == 3
     loaded_program = ProgramCls.from_precompiled(hub_repo, runtime_param="wassuhh")
     assert loaded_program.runtime_param == "wassuhh"
 
@@ -683,11 +650,8 @@ def test_no_config_w_retriever_hub(hub_repo: str):
 
     assert os.path.exists(staging_dir / "config.json")
     assert os.path.exists(staging_dir / "program.json")
-    assert os.path.exists(staging_dir / "README.md")
     assert os.path.exists(staging_dir / ".git")
-    assert os.path.exists(staging_dir / "LICENSE")
-    assert os.path.exists(staging_dir / "CONTRIBUTING.md")
-    assert len(os.listdir(staging_dir)) == 6
+    assert len(os.listdir(staging_dir)) == 3
     loaded_program = NoConfigWhRetrieverProgram.from_precompiled(hub_repo, runtime_param="wassuhh", retriever=retriever)
     assert loaded_program.runtime_param == "wassuhh"
 
@@ -701,11 +665,8 @@ def test_precompiled_program_hub_org(org_repo: str):
 
     assert os.path.exists(staging_dir / "config.json")
     assert os.path.exists(staging_dir / "program.json")
-    assert os.path.exists(staging_dir / "README.md")
-    assert os.path.exists(staging_dir / "LICENSE")
-    assert os.path.exists(staging_dir / "CONTRIBUTING.md")
     assert os.path.exists(staging_dir / ".git")
-    assert len(os.listdir(staging_dir)) == 6
+    assert len(os.listdir(staging_dir)) == 3
     loaded_program = ExampleProgram.from_precompiled(
         org_repo, runtime_param="wassuh", config={"lm": "openai/gpt-4o"}, rev=tag
     )

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -151,9 +151,6 @@ def test_predict_push_to_hub(hub_repo: str):
     assert commit.repo == hub_repo
     assert os.path.exists(staging_dir / "config.json")
     assert os.path.exists(staging_dir / "program.json")
-    assert os.path.exists(staging_dir / "README.md")
-    assert os.path.exists(staging_dir / "LICENSE")
-    assert os.path.exists(staging_dir / "CONTRIBUTING.md")
     assert os.path.exists(staging_dir / ".git")
 
 


### PR DESCRIPTION
Added the auto-resolve configuration to the pyproject.toml. This is used to specify which standard repo files will be automatically found and included in the repo pushed to judge. You can specify which files to auto-resolve in the root `pyproject.toml`.

```toml
[tool.modaic]
auto-resolve = ["readme"]
# auto-resolve = ["readme", "license"]
```

Available options are readme, license, and contributing.

When these are specified modaic will search you repo looking for these files. It will start its search in the same directory the source code of the program being pushed lives and work its way up to root.