### PR TITLE
fixed API BaseModel mismatch in FieldSchema

### DIFF
--- a/src/modaic-client/modaic_client/schemas.py
+++ b/src/modaic-client/modaic_client/schemas.py
@@ -75,8 +75,8 @@ class FieldSchema(BaseModel):
     def validate_schema(self):
         if self.type == "object" and self.allowed_values is not None:
             raise ValueError("Allowed values must be None if type is 'object'")
-        if self.schema is not None and self.type != "object":
-            raise ValueError("Schema must be None if type is not 'object'")
+        if self.object_schema is not None and self.type != "object":
+            raise ValueError("object_schema must be None if type is not 'object'")
         return self
 
 

--- a/src/modaic-sdk/modaic/batch/__init__.py
+++ b/src/modaic-sdk/modaic/batch/__init__.py
@@ -1,7 +1,6 @@
 from modaic.batch.batch import abatch, acancel_batch, aget_batch_results, submit_batch_job, supports_abatch
-from modaic.batch.types import ABatchResult, ABatchRow, FailedPrediction
 from modaic.batch.lmdb_cache import LmdbLMCache
-from modaic.batch.clients.vllm import VLLMBatchClient
+from modaic.batch.types import ABatchResult, ABatchRow, FailedPrediction
 
 __all__ = [
     "abatch",
@@ -15,3 +14,15 @@ __all__ = [
     "LmdbLMCache",
     "VLLMBatchClient",
 ]
+
+
+def __getattr__(name: str):
+    if name == "VLLMBatchClient":
+        from modaic.batch.clients.vllm import VLLMBatchClient
+
+        return VLLMBatchClient
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(__all__)

--- a/src/modaic-sdk/modaic/batch/adapters.py
+++ b/src/modaic-sdk/modaic/batch/adapters.py
@@ -8,7 +8,7 @@ import dspy
 import litellm
 from litellm import get_llm_provider as _get_llm_provider
 
-from .clients import BatchClient
+from .clients.base import BatchClient
 from .types import ABatchResult, ABatchRow, BatchRequest, BatchRequestItem, FailedPrediction, ResultItem
 
 logger = logging.getLogger(__name__)

--- a/src/modaic-sdk/modaic/batch/batch.py
+++ b/src/modaic-sdk/modaic/batch/batch.py
@@ -7,8 +7,16 @@ import dspy
 from litellm import get_llm_provider
 from rich.live import Live
 
-from .adapters import BatchAdapter, BatchChatAdapter, BatchJSONAdapter, BatchXMLAdapter, BatchRequestContext, BATCH_ADAPTERS, get_batch_adapter
-from .clients import BatchClient
+from .adapters import (
+    BATCH_ADAPTERS,
+    BatchAdapter,
+    BatchChatAdapter,
+    BatchJSONAdapter,
+    BatchRequestContext,
+    BatchXMLAdapter,
+    get_batch_adapter,
+)
+from .clients.base import BatchClient
 from .types import ABatchResult, ABatchRow, BatchReponse, BatchRequest, BatchRequestItem, FailedPrediction, ResultItem
 
 logger = logging.getLogger(__name__)
@@ -35,11 +43,11 @@ Vertex AI
 """
 
 CLIENTS: dict[str, tuple[str, str]] = {
-    "openai": ("modaic.batch.clients", "OpenAIBatchClient"),
-    "anthropic": ("modaic.batch.clients", "AnthropicBatchClient"),
-    "together_ai": ("modaic.batch.clients", "TogetherBatchClient"),
-    "azure": ("modaic.batch.clients", "AzureBatchClient"),
-    "fireworks_ai": ("modaic.batch.clients", "FireworksBatchClient"),
+    "openai": ("modaic.batch.clients.openai", "OpenAIBatchClient"),
+    "anthropic": ("modaic.batch.clients.anthropic", "AnthropicBatchClient"),
+    "together_ai": ("modaic.batch.clients.together", "TogetherBatchClient"),
+    "azure": ("modaic.batch.clients.azure", "AzureBatchClient"),
+    "fireworks_ai": ("modaic.batch.clients.fireworks", "FireworksBatchClient"),
 }
 
 

--- a/src/modaic-sdk/modaic/batch/clients/__init__.py
+++ b/src/modaic-sdk/modaic/batch/clients/__init__.py
@@ -1,19 +1,48 @@
-from .base import BatchClient
-from .openai import OpenAIBatchClient
-from .azure import AzureBatchClient
-from .together import TogetherBatchClient
-from .fireworks import FireworksBatchClient
-from .anthropic import AnthropicBatchClient
-from .vertex import VertexAIBatchClient
-from .vllm import VLLMBatchClient
+"""Batch provider clients.
+
+Concrete implementations live in submodules (for example ``modaic.batch.clients.openai``).
+This package does not import them at load time so optional dependencies stay lazy.
+``get_batch_client`` in :mod:`modaic.batch.batch` imports only the submodule for
+the selected provider.
+
+For backwards compatibility, attribute access on ``modaic.batch.clients`` resolves
+names lazily via :func:`__getattr__`.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
 
 __all__ = [
-    "BatchClient",
-    "OpenAIBatchClient",
-    "AzureBatchClient",
-    "TogetherBatchClient",
-    "FireworksBatchClient",
     "AnthropicBatchClient",
+    "AzureBatchClient",
+    "BatchClient",
+    "FireworksBatchClient",
+    "OpenAIBatchClient",
+    "TogetherBatchClient",
     "VertexAIBatchClient",
     "VLLMBatchClient",
 ]
+
+_EXPORTS: dict[str, tuple[str, str]] = {
+    "BatchClient": (".base", "BatchClient"),
+    "OpenAIBatchClient": (".openai", "OpenAIBatchClient"),
+    "AzureBatchClient": (".azure", "AzureBatchClient"),
+    "TogetherBatchClient": (".together", "TogetherBatchClient"),
+    "FireworksBatchClient": (".fireworks", "FireworksBatchClient"),
+    "AnthropicBatchClient": (".anthropic", "AnthropicBatchClient"),
+    "VertexAIBatchClient": (".vertex", "VertexAIBatchClient"),
+    "VLLMBatchClient": (".vllm", "VLLMBatchClient"),
+}
+
+
+def __getattr__(name: str):
+    if name not in _EXPORTS:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    submod, attr = _EXPORTS[name]
+    module = import_module(submod, __name__)
+    return getattr(module, attr)
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/src/modaic-sdk/modaic/batch/clients/anthropic.py
+++ b/src/modaic-sdk/modaic/batch/clients/anthropic.py
@@ -7,14 +7,16 @@ try:
     import anthropic
 except ModuleNotFoundError as exc:
     raise ModuleNotFoundError(
-        'modaic.batch requires the Anthropic SDK for Anthropic batch jobs. Install it with `uv add "modaic[anthropic]"`.'
+        'modaic.batch.anthropic requires the Anthropic SDK for Anthropic batch jobs. '
+        'Install it with `uv add "modaic[anthropic]"`.'
     ) from exc
 
 try:
     import httpx
 except ModuleNotFoundError as exc:
     raise ModuleNotFoundError(
-        'modaic.batch requires `httpx` for Anthropic batch jobs. Install it with `uv add "modaic[anthropic]"`.'
+        'modaic.batch.anthropic requires httpx for Anthropic batch jobs. '
+        'Install it with `uv add "modaic[anthropic]"`.'
     ) from exc
 
 from ..types import BatchReponse, BatchRequest, ResultItem

--- a/src/modaic-sdk/modaic/batch/clients/azure.py
+++ b/src/modaic-sdk/modaic/batch/clients/azure.py
@@ -8,7 +8,8 @@ try:
     from openai import AsyncAzureOpenAI
 except ModuleNotFoundError as exc:
     raise ModuleNotFoundError(
-        'modaic.batch requires the OpenAI SDK for Azure batch jobs. Install it with `uv add "modaic[azure]"`.'
+        'modaic.batch.azure requires the OpenAI SDK for Azure batch jobs. '
+        'Install it with `uv add "modaic[azure]"`.'
     ) from exc
 
 from ..types import BatchReponse, BatchRequest, ResultItem

--- a/src/modaic-sdk/modaic/batch/clients/fireworks.py
+++ b/src/modaic-sdk/modaic/batch/clients/fireworks.py
@@ -12,7 +12,8 @@ try:
     import httpx
 except ModuleNotFoundError as exc:
     raise ModuleNotFoundError(
-        'modaic.batch requires `httpx` for Fireworks batch jobs. Install it with `uv add "modaic[fireworks]"`.'
+        'modaic.batch.fireworks_ai requires httpx for Fireworks batch jobs. '
+        'Install it with `uv add "modaic[fireworks]"`.'
     ) from exc
 
 from ..storage import ensure_batch_storage_dirs

--- a/src/modaic-sdk/modaic/batch/clients/openai.py
+++ b/src/modaic-sdk/modaic/batch/clients/openai.py
@@ -8,7 +8,8 @@ try:
     from openai import AsyncOpenAI
 except ModuleNotFoundError as exc:
     raise ModuleNotFoundError(
-        'modaic.batch requires the OpenAI SDK for OpenAI batch jobs. Install it with `uv add "modaic[openai]"`.'
+        'modaic.batch.openai requires the OpenAI SDK for OpenAI batch jobs. '
+        'Install it with `uv add "modaic[openai]"`.'
     ) from exc
 
 from ..types import BatchReponse, BatchRequest, ResultItem

--- a/src/modaic-sdk/modaic/batch/clients/together.py
+++ b/src/modaic-sdk/modaic/batch/clients/together.py
@@ -9,7 +9,8 @@ try:
     from together import AsyncTogether
 except ModuleNotFoundError as exc:
     raise ModuleNotFoundError(
-        'modaic.batch requires the Together SDK for Together batch jobs. Install it with `uv add "modaic[together]"`.'
+        'modaic.batch.together_ai requires the Together SDK for Together batch jobs. '
+        'Install it with `uv add "modaic[together]"`.'
     ) from exc
 
 from ..types import BatchReponse, BatchRequest, ResultItem

--- a/src/modaic-sdk/modaic/batch/clients/vllm.py
+++ b/src/modaic-sdk/modaic/batch/clients/vllm.py
@@ -22,6 +22,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _require_vllm() -> None:
+    try:
+        import vllm  # noqa: F401
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "modaic.batch.vllm requires the vLLM package for vLLM batch jobs. "
+            'Install it with `uv add "modaic[vllm]"`.'
+        ) from exc
+
+
 class VLLMBatchClient(BatchClient):
     """Resumable vLLM batch client using the Python API with mini-batching and LMDB caching.
 
@@ -175,6 +185,7 @@ class VLLMBatchClient(BatchClient):
 
     def _parse_vllm_args(self, input_file: str = "/dev/null", output_file: str = "/dev/null"):
         """Parse CLI args through vLLM's own argument parser to get a complete Namespace."""
+        _require_vllm()
         from vllm.entrypoints.openai.run_batch import make_arg_parser
         from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -189,11 +200,10 @@ class VLLMBatchClient(BatchClient):
     @asynccontextmanager
     async def start(self) -> AsyncIterator[None]:
         """Create the vLLM engine and hold it open for the duration."""
+        args = self._parse_vllm_args()
         from vllm.engine.arg_utils import AsyncEngineArgs
         from vllm.entrypoints.openai.api_server import build_async_engine_client_from_engine_args
         from vllm.usage.usage_lib import UsageContext
-
-        args = self._parse_vllm_args()
         engine_args = AsyncEngineArgs.from_cli_args(args)
 
         logger.info(
@@ -281,6 +291,7 @@ class VLLMBatchClient(BatchClient):
         total_batches: int,
     ) -> list[dict[str, Any]]:
         """Write JSONL, call ``run_batch``, read output, return parsed rows."""
+        _require_vllm()
         from vllm.entrypoints.openai.run_batch import run_batch
 
         with NamedTemporaryFile("w", suffix=".jsonl", delete=False) as f:


### PR DESCRIPTION
Fixed `FieldSchema` BaseModel mismatch with the modaic.dev API. Also migrated batch clients to using lazy import style to avoid eager loading of optional modules that may not be installed.