### PR TITLE
Fix image paths in Arbiters + Braintrust and LangSmith docs

### DIFF
--- a/docs/docs/arbiters/braintrust-integration.mdx
+++ b/docs/docs/arbiters/braintrust-integration.mdx
@@ -12,10 +12,10 @@ You can use an arbiter as a code scorer in [Braintrust](https://www.braintrust.d
 ## Set the MODAIC_TOKEN
 
 In Braintrust, click on the "Settings" tab at the bottom of the sidebar menu
-![Settings Tab](./assets/braintrust/settings.png)
+![Settings Tab](/docs/arbiters/assets/braintrust/settings.png)
 
 In the Settings menu, click on the "Env variables" tab and add your `MODAIC_TOKEN` as an environment variable.
-![Env Variables](./assets/braintrust/env_variables.png)
+![Env Variables](/docs/arbiters/assets/braintrust/env_variables.png)
 
 ## Create a Code Scorer
 

--- a/docs/docs/arbiters/langsmith-integration.mdx
+++ b/docs/docs/arbiters/langsmith-integration.mdx
@@ -8,22 +8,22 @@ You can use an Arbiter from Modaic as an LM judge in [LangSmith](https://smith.l
 1. [Create your arbiter](/docs/arbiters/create_an_arbiter).
 
 2. Navigate to the **Prompts** tab in LangSmith and click the **+ Prompt** button.
-![Prompts Tab](./assets/langsmith/prompts_tab.png)
+![Prompts Tab](/docs/arbiters/assets/langsmith/prompts_tab.png)
 
 3. Click the model name to configure provider settings.
-![New Prompt](./assets/langsmith/new_prompt.png)
+![New Prompt](/docs/arbiters/assets/langsmith/new_prompt.png)
 
 4. Set the provider to **OpenAI Compatible Endpoint**.
-![Select Provider](./assets/langsmith/select_provider.png)
+![Select Provider](/docs/arbiters/assets/langsmith/select_provider.png)
 
 5. Set the model to the name of your arbiter on Modaic. It should be in the format `<entity>/<arbiter-name>`.
-![Model Name](./assets/langsmith/enter_repo.png)
+![Model Name](/docs/arbiters/assets/langsmith/enter_repo.png)
 
 6. Select **Chat Completions** as the **Provider API** and set the **Base URL** to:
 ```
 https://api.modaic.dev/api/v1/arbiters
 ```
-![Base URL](./assets/langsmith/set_base_url.png)
+![Base URL](/docs/arbiters/assets/langsmith/set_base_url.png)
 
 7. Save the provider configuration.
 
@@ -31,11 +31,11 @@ https://api.modaic.dev/api/v1/arbiters
 
 <Tabs>
 <Tab title="Browser Secrets">
-![Browser Secrets](./assets/langsmith/set_browser_secret.png)
+![Browser Secrets](/docs/arbiters/assets/langsmith/set_browser_secret.png)
 </Tab>
 <Tab title="Workspace Secrets">
-![Workspace Secrets](./assets/langsmith/see_ws_secrets.png)
-![Set Workspace Secret](./assets/langsmith/workspace_secrets.png)
+![Workspace Secrets](/docs/arbiters/assets/langsmith/see_ws_secrets.png)
+![Set Workspace Secret](/docs/arbiters/assets/langsmith/workspace_secrets.png)
 </Tab>
 </Tabs>
 
@@ -56,7 +56,7 @@ Use XML tags to wrap the input fields for your arbiter. For example, if your arb
 
 In LangSmith, `{inputs.title}` retrieves the `title` field from the inputs of a dataset row or run. This is forwarded to the prompt template and wrapped with XML tags that inform Modaic which field corresponds to which input.
 
-![Prompt Template](./assets/langsmith/prompt_template.png)
+![Prompt Template](/docs/arbiters/assets/langsmith/prompt_template.png)
 
 <Warning>
 Modaic's backend does not execute the LLM as a standard completions endpoint. 


### PR DESCRIPTION
Use absolute paths from the docs root so Mintlify resolves the
asset URLs correctly, matching the convention used elsewhere
(e.g. /images/mo-architecture.png in introduction.mdx).

https://claude.ai/code/session_014p5BRbeCmVD2Jbx9JfJdes