### PR TITLE
Fix Vercel AI Gateway predictions for gpt-oss-120b

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -16,6 +16,8 @@ jobs:
 
       - run: uv tool install ruff>=0.12.7 # pin version for reproducibility
 
-      - run: ruff check modaic --output-format=github
+      # The package lives at src/modaic-sdk/modaic (not a top-level modaic/),
+      # so reference it by path from the repo root.
+      - run: ruff check src/modaic-sdk/modaic --output-format=github
 
-      - run: ruff format modaic --check
+      - run: ruff format src/modaic-sdk/modaic --check

--- a/src/modaic-sdk/modaic/_litellm_provider.py
+++ b/src/modaic-sdk/modaic/_litellm_provider.py
@@ -35,6 +35,37 @@ class _ModaicProviderConfig(SimpleProviderConfig):
         pass
 
 
+# Models served through an OpenAI-compatible gateway (e.g. Vercel AI Gateway)
+# whose litellm entry does not advertise structured-output support, but which
+# DO accept an OpenAI `json_schema` response_format. Without this, dspy's
+# JSONAdapter sees ``supports_response_schema == False`` and falls back to
+# ``response_format={"type": "json_object"}`` — which the Vercel AI Gateway
+# rejects for these models with ``400 "Invalid input"``. Registering them as
+# ``supports_response_schema`` keeps dspy on the structured (json_schema) path.
+#
+# Key is the *bare* model id (no provider prefix): litellm strips the gateway
+# provider before looking the model up in its registry, so registering the
+# fully-qualified ``vercel_ai_gateway/openai/gpt-oss-120b`` would not match.
+_GATEWAY_STRUCTURED_OUTPUT_MODELS = ("openai/gpt-oss-120b",)
+
+
+def _register_gateway_structured_output_support() -> None:
+    """Tell litellm the gateway-served models below accept ``json_schema``.
+
+    Idempotent: ``register_model`` merges into ``litellm.model_cost``.
+    """
+    for model in _GATEWAY_STRUCTURED_OUTPUT_MODELS:
+        litellm.register_model(
+            {
+                model: {
+                    "supports_response_schema": True,
+                    "litellm_provider": "vercel_ai_gateway",
+                    "mode": "chat",
+                }
+            }
+        )
+
+
 def register_modaic_provider() -> None:
     """Idempotently register the `modaic` provider with litellm."""
     JSONProviderRegistry._providers["modaic"] = _ModaicProviderConfig()
@@ -43,3 +74,4 @@ def register_modaic_provider() -> None:
 
 
 register_modaic_provider()
+_register_gateway_structured_output_support()

--- a/tests/test_litellm_provider.py
+++ b/tests/test_litellm_provider.py
@@ -1,0 +1,34 @@
+"""Regression tests for ``modaic/_litellm_provider.py``.
+
+These are hermetic — they assert the litellm registry state that ``import modaic``
+sets up, without making any network calls.
+"""
+
+import litellm
+import modaic  # noqa: F401  (import side effect registers providers + model caps)
+
+
+def test_modaic_provider_registered() -> None:
+    """The ``modaic/`` provider is registered with litellm on import."""
+    assert "modaic" in litellm.provider_list
+
+
+def test_gateway_gpt_oss_supports_response_schema() -> None:
+    """gpt-oss-120b on the Vercel AI Gateway is marked structured-output capable.
+
+    Without this, dspy's ``JSONAdapter`` sees ``supports_response_schema is False``
+    and falls back to ``response_format={"type": "json_object"}``, which the Vercel
+    AI Gateway rejects with ``400 "Invalid input"`` for this model. Keeping the flag
+    True holds dspy on the ``json_schema`` path the gateway accepts.
+
+    Asserted at the litellm layer (where the fix lives and where dspy reads it),
+    so it is robust across dspy versions. ``custom_llm_provider`` mirrors how dspy
+    resolves the gateway provider before the litellm lookup.
+    """
+    assert (
+        litellm.supports_response_schema(
+            model="vercel_ai_gateway/openai/gpt-oss-120b",
+            custom_llm_provider="vercel_ai_gateway",
+        )
+        is True
+    )


### PR DESCRIPTION
## Problem

Predictions whose arbiter LM is `vercel_ai_gateway/openai/gpt-oss-120b` fail. Locally this surfaces as:

```
litellm.BadRequestError: Vercel_ai_gatewayException - Invalid input
```

On the platform it surfaces as an empty `{}` prediction → `1 validation error for PredictionOutput / score Field required` → HTTP 500.

This is **not** an auth / API-key / env-var problem — the gateway key works fine for direct calls.

## Root cause

1. litellm's model registry reports `supports_response_schema == False` for `vercel_ai_gateway/openai/gpt-oss-120b`.
2. So dspy's `JSONAdapter` uses `response_format={"type": "json_object"}`.
3. The Vercel AI Gateway **rejects `json_object`** for gpt-oss-120b with `400 "Invalid input"`. It **accepts** an OpenAI `json_schema` response_format (verified).
4. gpt-oss arbiters always reach the JSON path: the signature's `reasoning` (`modaic` `Reasoning`) output field makes the plain-text `ChatAdapter` parse fall through to the JSON adapter.

Net effect: every gpt-oss-120b-via-gateway prediction dies on the rejected `json_object` request.

## Fix

Register `openai/gpt-oss-120b` with `supports_response_schema: True` at import time (`_litellm_provider.py`). This keeps dspy on the structured `json_schema` path the gateway accepts.

- Key is the **bare** model id (`openai/gpt-oss-120b`), because litellm strips the gateway provider prefix before the registry lookup — registering the fully-qualified `vercel_ai_gateway/...` string would not match.
- `litellm.register_model` merges into `litellm.model_cost`, so this is idempotent and additive.

## Verification

End-to-end against the **prod** arbiter (`modaic/vercel-email-scoring`) through the real `modaic.Predict` path, run the way the server runs it (dspy disk/memory cache disabled, fresh unique inputs each run):

| | result |
|---|---|
| before fix | `BadRequestError: ... Invalid input` (3/3 runs) |
| after fix | `{score, reasoning}` returned (3/3 runs) |

Added `tests/test_litellm_provider.py` — hermetic (no network): asserts the `modaic` provider is registered and that `litellm.supports_response_schema(...)` is `True` for the gateway model. Passes under the SDK's pinned dspy 3.1.2 / litellm 1.83.14.

## Platform follow-up

The platform (`modaic-dev`) picks this up by **bumping the `modaic` dependency** and redeploying — no platform code change required. Separate PR.

## Note on scope

Marking `openai/gpt-oss-120b` as response-schema-capable applies to any provider serving that suffix (correct — gpt-oss-120b does support structured outputs where offered, and harmless elsewhere). Extend `_GATEWAY_STRUCTURED_OUTPUT_MODELS` for additional gateway-served reasoning models as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)