### PR TITLE
fix(hub): reset cached branches instead of git pull; no-op on nothing-to-commit

### DIFF
--- a/src/modaic-sdk/modaic/hub.py
+++ b/src/modaic-sdk/modaic/hub.py
@@ -2,6 +2,7 @@ import re
 import shutil
 import subprocess
 import sys
+import warnings
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -233,7 +234,15 @@ def _smart_commit(repo: git.Repo, commit_message: str, access_token: str) -> Non
         repo.git.commit("-m", commit_message)
     except git.exc.GitCommandError as e:
         if "nothing to commit" in str(e).lower():
-            raise ModaicError("Nothing to commit") from None
+            # The working tree already matches the latest commit. Treat this as a no-op
+            # instead of an error: skip the commit and let the caller proceed to push
+            # (an up-to-date push is itself a no-op, so nothing further happens).
+            warnings.warn(
+                "Nothing to commit: the working tree already matches the latest commit. Skipping commit (no-op).",
+                UserWarning,
+                stacklevel=2,
+            )
+            return
         raise ModaicError(f"Git commit failed: {e.stderr}") from e
 
 
@@ -315,7 +324,13 @@ def git_snapshot(
                 main_repo.git.worktree("add", str(rev_dir.resolve()), f"origin/{revision.name}")
             else:
                 repo = git.Repo(rev_dir)
-                repo.remotes.origin.pull(revision.name)
+                # No history merging: our hub checkouts are always expected to already be in
+                # sync with the hub (commits and pushes are atomic in our workflow). Hard-reset
+                # the cached worktree to origin instead of pulling, which avoids the "Need to
+                # specify how to reconcile divergent branches" failure and is purely local
+                # (origin/<branch> was already refreshed by the fetch above), so no extra
+                # network round-trip is added on this potentially hot reload path.
+                repo.git.reset("--hard", f"origin/{revision.name}")
 
             # get the up to date sha for the branch
             revision = resolve_revision(main_repo, f"origin/{revision.name}")

--- a/tests/modaic_client/conftest.py
+++ b/tests/modaic_client/conftest.py
@@ -5,7 +5,6 @@ import dspy
 import modaic
 import pytest
 from modaic_client.client import ModaicClient
-from modaic_client.exceptions import ModaicError
 
 MODAIC_TOKEN = os.getenv("MODAIC_TOKEN")
 
@@ -39,10 +38,7 @@ def test_arbiter(test_arbiter_client):
         lm=modaic.SafeLM(model="together_ai/openai/gpt-oss-120b"),
     )
     arbiter = predictor.as_arbiter()
-    try:
-        arbiter.push_to_hub(TEST_ARBITER_REPO, commit_message="test arbiter setup")
-    except ModaicError as e:
-        if "Nothing to commit" not in str(e):
-            raise
+    # push_to_hub is a no-op (warns) when there is nothing to commit, so no special handling needed.
+    arbiter.push_to_hub(TEST_ARBITER_REPO, commit_message="test arbiter setup")
 
     return test_arbiter_client.get_arbiter(TEST_ARBITER_REPO)

--- a/tests/test_hub_git.py
+++ b/tests/test_hub_git.py
@@ -1,0 +1,91 @@
+"""Pure-git regression tests for hub.git_snapshot's branch-reload strategy.
+
+These tests do not touch the Modaic hub (no MODAIC_TOKEN required). They lock in
+the decision to hard-reset cached branch worktrees to ``origin/<branch>`` instead
+of running ``git pull``. ``git pull`` fails with
+"fatal: Need to specify how to reconcile divergent branches." when the cached
+checkout has diverged from origin (observed in production); a hard reset recovers
+cleanly because our hub checkouts are always expected to already be in sync.
+"""
+
+from pathlib import Path
+
+import git
+import pytest
+
+
+def _commit_file(repo: git.Repo, path: Path, content: str, message: str) -> None:
+    path.write_text(content)
+    repo.git.add("-A")
+    repo.git.commit("-m", message)
+
+
+def _init_repo(path: Path, bare: bool = False) -> git.Repo:
+    repo = git.Repo.init(path, bare=bare)
+    if not bare:
+        repo.git.config("user.email", "test@modaic.dev")
+        repo.git.config("user.name", "modaic-test")
+    return repo
+
+
+def test_hard_reset_recovers_where_pull_fails_on_divergence(tmp_path: Path):
+    """reset --hard origin/<branch> recovers a diverged checkout; git pull does not."""
+    # Bare "remote" seeded with an initial main commit.
+    bare = tmp_path / "remote.git"
+    _init_repo(bare, bare=True)
+
+    seed = _init_repo(tmp_path / "seed")
+    _commit_file(seed, tmp_path / "seed" / "a.txt", "v1", "init")
+    seed.create_remote("origin", str(bare))
+    seed.remotes.origin.push("HEAD:refs/heads/main")
+
+    # The cached checkout git_snapshot maintains: a clone tracking origin/main.
+    cache = git.Repo.clone_from(str(bare), tmp_path / "cache", multi_options=["--branch", "main"])
+    cache.git.config("user.email", "test@modaic.dev")
+    cache.git.config("user.name", "modaic-test")
+
+    # Simulate divergence: cache gains a local-only commit while origin/main is
+    # advanced to an unrelated commit. (Should never happen in our workflow, but did
+    # in production per the Sentry report.)
+    _commit_file(cache, tmp_path / "cache" / "a.txt", "local-only", "local divergence")
+
+    other = git.Repo.clone_from(str(bare), tmp_path / "other")
+    other.git.config("user.email", "test@modaic.dev")
+    other.git.config("user.name", "modaic-test")
+    _commit_file(other, tmp_path / "other" / "a.txt", "remote-v2", "remote update")
+    other.remotes.origin.push("main")
+
+    cache.remotes.origin.fetch()
+
+    # What hub.py used to do: git pull. Force ff-only so the failure is deterministic
+    # across git versions / user config (the production failure was the default
+    # "divergent branches" variant of the same can't-reconcile condition).
+    cache.git.config("pull.ff", "only")
+    with pytest.raises(git.exc.GitCommandError):
+        cache.remotes.origin.pull("main")
+
+    # What hub.py does now: hard reset to origin recovers cleanly.
+    cache.git.reset("--hard", "origin/main")
+    assert (tmp_path / "cache" / "a.txt").read_text() == "remote-v2"
+    assert cache.head.commit.hexsha == cache.commit("origin/main").hexsha
+
+
+def test_hard_reset_is_noop_when_already_in_sync(tmp_path: Path):
+    """When the checkout already matches origin, reset --hard is a clean no-op (no network)."""
+    bare = tmp_path / "remote.git"
+    _init_repo(bare, bare=True)
+
+    seed = _init_repo(tmp_path / "seed")
+    _commit_file(seed, tmp_path / "seed" / "a.txt", "v1", "init")
+    seed.create_remote("origin", str(bare))
+    seed.remotes.origin.push("HEAD:refs/heads/main")
+
+    cache = git.Repo.clone_from(str(bare), tmp_path / "cache", multi_options=["--branch", "main"])
+    before = cache.head.commit.hexsha
+
+    cache.remotes.origin.fetch()
+    cache.git.reset("--hard", "origin/main")
+
+    assert cache.head.commit.hexsha == before
+    assert (tmp_path / "cache" / "a.txt").read_text() == "v1"
+    assert not cache.is_dirty()

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -488,3 +488,95 @@ def test_predict_tag(hub_repo: str):
     # Main should have new model
     main_after = Predict.from_precompiled(hub_repo, rev="main")
     assert main_after.config.model == "openai/gpt-4o"
+
+
+def test_predict_push_nothing_to_commit_is_noop(hub_repo: str):
+    """Re-pushing identical content to an existing branch is a no-op.
+
+    Previously this raised ModaicError("Nothing to commit"). Now it warns and
+    returns the existing commit unchanged (no new commit is created).
+    """
+    config = PredictConfig(signature=SummarizeSignature, model="openai/gpt-4o-mini")
+    predict1 = Predict(config)
+    commit1 = predict1.push_to_hub(hub_repo, branch="main")
+
+    # Build an identical program (same config) from the loaded source and re-push.
+    loaded = Predict.from_precompiled(hub_repo, rev="main")
+    predict2 = Predict(PredictConfig(signature=SummarizeSignature, model="openai/gpt-4o-mini"))
+    predict2._source = loaded._source
+    predict2._source_commit = loaded._source_commit
+
+    with pytest.warns(UserWarning, match="[Nn]othing to commit"):
+        commit2 = predict2.push_to_hub(hub_repo, branch="main")
+
+    # No exception, and the returned commit is the unchanged existing commit.
+    assert commit2 is not None
+    assert commit2.sha == commit1.sha
+
+    # Content is still intact and loadable.
+    reloaded = Predict.from_precompiled(hub_repo, rev="main")
+    assert reloaded.config.model == "openai/gpt-4o-mini"
+    assert reloaded.config.signature.equals(SummarizeSignature)
+
+
+def test_predict_new_branch_identical_to_base_creates_branch(hub_repo: str):
+    """Creating a new branch whose content equals its base warns but still creates the branch.
+
+    Previously this raised ModaicError("Nothing to commit") and the branch was not
+    created. Now it warns (nothing to commit) and creates the branch pointing at the
+    base commit.
+    """
+    config = PredictConfig(signature=SummarizeSignature, model="openai/gpt-4o-mini")
+    predict1 = Predict(config)
+    commit_main = predict1.push_to_hub(hub_repo, branch="main")
+
+    loaded = Predict.from_precompiled(hub_repo, rev="main")
+    predict2 = Predict(PredictConfig(signature=SummarizeSignature, model="openai/gpt-4o-mini"))
+    predict2._source = loaded._source
+    predict2._source_commit = loaded._source_commit
+
+    with pytest.warns(UserWarning, match="[Nn]othing to commit"):
+        commit_branch = predict2.push_to_hub(hub_repo, branch="identical-dev")
+
+    # Branch is created and points at the same commit as its base (main).
+    assert commit_branch is not None
+    assert commit_branch.sha == commit_main.sha
+
+    # Branch is loadable with the expected content.
+    dev_loaded = Predict.from_precompiled(hub_repo, rev="identical-dev")
+    assert dev_loaded.config.model == "openai/gpt-4o-mini"
+    assert dev_loaded.config.signature.equals(SummarizeSignature)
+
+
+def test_predict_reload_branch_reflects_remote_update(hub_repo: str):
+    """A cached branch reload reflects remote updates (git_snapshot reset path).
+
+    The second+ load of a branch hits the cached-worktree path in git_snapshot,
+    which now hard-resets to origin/<branch> instead of `git pull`. This verifies
+    that path returns up-to-date content.
+    """
+    # Seed main and dev with the same model.
+    predict_main = Predict(PredictConfig(signature=SummarizeSignature, model="openai/gpt-4o-mini"))
+    predict_main.push_to_hub(hub_repo, branch="main")
+    loaded_main = Predict.from_precompiled(hub_repo, rev="main")
+
+    predict_dev1 = Predict(PredictConfig(signature=SummarizeSignature, model="openai/gpt-4o-mini"))
+    predict_dev1._source = loaded_main._source
+    predict_dev1._source_commit = loaded_main._source_commit
+    predict_dev1.push_to_hub(hub_repo, branch="dev")
+
+    # First load creates the cached worktree for dev.
+    dev_first = Predict.from_precompiled(hub_repo, rev="dev")
+    assert dev_first.config.model == "openai/gpt-4o-mini"
+
+    # Update dev on the remote with a different model.
+    loaded_dev = Predict.from_precompiled(hub_repo, rev="dev")
+    predict_dev2 = Predict(PredictConfig(signature=SummarizeSignature, model="openai/gpt-4o"))
+    predict_dev2._source = loaded_dev._source
+    predict_dev2._source_commit = loaded_dev._source_commit
+    predict_dev2.push_to_hub(hub_repo, branch="dev")
+
+    # The next load reuses the cached worktree (reset --hard origin/dev) and must
+    # reflect the update.
+    dev_second = Predict.from_precompiled(hub_repo, rev="dev")
+    assert dev_second.config.model == "openai/gpt-4o"


### PR DESCRIPTION
## Summary

Two robustness fixes to the git workflow in `hub.py`, both surfaced by a Sentry report:

> `Failed to create prediction Cmd('git') failed ... git pull -v -- origin main ... fatal: Need to specify how to reconcile divergent branches.`

### 1. `git_snapshot`: hard-reset cached branches instead of `git pull`
On a cached-branch reload, the worktree is now hard-reset to `origin/<branch>` instead of `git pull`. Our hub checkouts are always expected to already be in sync (commits and pushes are atomic in our workflow), so no history merging is wanted.

- **Fixes the divergent-branches crash** — `reset --hard` never tries to reconcile histories.
- **Lower latency in the hot path** — `reset` is purely local; `origin/<branch>` is already refreshed by the `fetch()` at the top of `git_snapshot`, so it adds **zero** network round-trips (vs. `pull`'s extra fetch+merge). The every-30s no-change reload stays cheap.
- **No new assumptions** — inside the `revision.type == "branch"` block, `revision.name` is always a bare branch name (commits/tags route to the `worktree add revision.sha` path), and the next line already relies on `origin/<branch>` being a valid ref.

### 2. `_smart_commit`: no-op + warn on "nothing to commit"
Re-pushing identical content previously raised `ModaicError("Nothing to commit")` (and wiped the staging dir). It now emits a `UserWarning` and proceeds. An up-to-date push is itself a no-op (verified: GitPython returns `[up to date]`, exit 0), so:

- Re-pushing identical content → returns the existing commit (no-op).
- Creating a new branch identical to its base → the branch is now **created** at the base commit (previously errored).
- `_attempt_push` is unchanged; tag-already-exists still raises.

Also simplifies the `modaic_client` test fixture that previously swallowed the `"Nothing to commit"` error.

## Behavior changes
- Re-push identical content: error → no-op success (warning), staging dir no longer wiped.
- New branch identical to base: error → branch created (warning).
- Re-push identical content **with a new tag**: now tags the existing commit and pushes the tag.

## Tests
- `tests/test_hub_git.py` (new, pure-git, no hub needed): proves `reset --hard origin/<branch>` recovers from a diverged checkout where `git pull` raises, and is a clean no-op when already in sync.
- `test_programs.py`: `nothing_to_commit_is_noop`, `new_branch_identical_to_base_creates_branch`, `reload_branch_reflects_remote_update`.

### Validation
- New pure-git tests: 2 passed.
- New hub integration tests: 3 passed.
- `test_precompiled.py` + `test_probe.py`: 35 passed, 2 skipped.
- `modaic_client` + `test_programs.py` + `test_auto.py`: 108 passed (1 pre-existing unrelated failure: `test_predict_delegates_to_client`, a stale mock test that fails identically on `main`).
- ruff check + format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)