### PR TITLE
Fix NDJSON splitting in BatchJob.results() on U+2028/U+2029

### DIFF
--- a/src/modaic-client/modaic_client/client.py
+++ b/src/modaic-client/modaic_client/client.py
@@ -192,6 +192,31 @@ def _iter_sse_events(response: httpx.Response) -> Iterator[dict]:
             data_buffer.append(line[len("data:") :].lstrip())
 
 
+def _iter_ndjson_lines(response: httpx.Response) -> Iterator[bytes]:
+    """Yield one NDJSON record per ``\\n``-terminated line, splitting on raw
+    bytes. ``httpx.Response.iter_lines()`` decodes to ``str`` and splits with
+    ``str.splitlines()``, which also breaks on ``\\r``, ``\\v``, ``\\f``,
+    ``\\x1c``-``\\x1e``, ``\\x85``, ``U+2028`` and ``U+2029``. Pydantic's
+    ``model_dump_json`` does not escape the unicode line separators, so user
+    content containing them (e.g. scraped prose) would split a single JSON
+    record into two pieces and raise ``JSONDecodeError``."""
+    buffer = b""
+    for chunk in response.iter_bytes():
+        if not chunk:
+            continue
+        buffer += chunk
+        while True:
+            nl = buffer.find(b"\n")
+            if nl < 0:
+                break
+            line = buffer[:nl]
+            buffer = buffer[nl + 1 :]
+            if line:
+                yield line
+    if buffer:
+        yield buffer
+
+
 def _make_progress_bar(total: int):
     """Return a tqdm bar for ``total`` predictions. Imported lazily so a
     headless caller that never sets ``show_progress=True`` doesn't pay the
@@ -257,10 +282,8 @@ class BatchJob:
             ) as response:
                 raise_errors(response)
                 rows: list[BatchExampleResult] = []
-                for line in response.iter_lines():
-                    if not line:
-                        continue
-                    payload = json.loads(line)
+                for raw_line in _iter_ndjson_lines(response):
+                    payload = json.loads(raw_line)
                     predictions = [
                         self.client._build_arbiter_prediction(
                             arbiter_repo=self._arbiter_for_index(i),

--- a/tests/modaic_client/test_modaic_client.py
+++ b/tests/modaic_client/test_modaic_client.py
@@ -684,6 +684,49 @@ class TestBatchJobStreamingUnit:
         # `.confidence` doesn't block on the wait_for_confidence_score path.
         assert out[0].predictions[0]._confidence == 0.7
 
+    def test_results_splits_only_on_newline_not_unicode_line_separators(self):
+        """Regression: ``httpx.Response.iter_lines()`` uses ``str.splitlines()``
+        under the hood, which also breaks on ``U+2028`` and ``U+2029``.
+        Pydantic's ``model_dump_json`` leaves those characters raw, so a single
+        NDJSON record containing scraped prose (e.g. LitBench rationales) was
+        being split mid-string and raised ``JSONDecodeError``."""
+        body = (
+            json.dumps(
+                {
+                    "example_id": "ex-1",
+                    "input": {"story": "line one line two line three"},
+                    "predictions": [
+                        {
+                            "prediction_id": "p-1",
+                            "output": {"answer": "ok"},
+                            "reasoning": "rationale with a separator inside",
+                            "messages": [],
+                            "confidence": None,
+                        }
+                    ],
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        ).encode("utf-8")
+
+        def handler(request):
+            assert request.url.path.endswith("/results")
+            return httpx.Response(
+                200,
+                content=body,
+                headers={"content-type": "application/x-ndjson"},
+            )
+
+        c = _make_mock_client(handler)
+        job = BatchJob(client=c, job_id="j1", total=1, arbiters=["a/b"])
+
+        out = job.results()
+        assert len(out) == 1
+        assert out[0].example_id == "ex-1"
+        assert out[0].input["story"] == "line one line two line three"
+        assert out[0].predictions[0].reasoning == "rationale with a separator inside"
+
     def test_wait_raises_on_failed_status(self):
         events_body = self._sse_payload(
             self._snapshot(event="finish", status="failed", error="boom"),


### PR DESCRIPTION
httpx.Response.iter_lines() decodes to str and splits with str.splitlines(), which breaks on U+2028 and U+2029 in addition to \n. Pydantic's model_dump_json leaves those raw, so scraped prose (e.g. LitBench rationales) sliced a single NDJSON record into two pieces and raised JSONDecodeError. Switch to a raw-bytes iterator that splits only on \n.