### PR TITLE
modaic-client: switch annotate to v2 endpoint, deprecate v1

### DIFF
--- a/src/modaic-client/modaic_client/client.py
+++ b/src/modaic-client/modaic_client/client.py
@@ -1,8 +1,9 @@
 import json
 import threading
 import time
+import warnings
 from contextlib import contextmanager
-from typing import Any, Callable, Iterator, Literal, Optional
+from typing import Any, Callable, Iterator, Literal, Optional, Union
 
 import httpx
 from pydantic import BaseModel, PrivateAttr
@@ -507,8 +508,20 @@ class Arbiter:
         return self.client.get_example(example_id)
 
     def annotate_example(
-        self, example_id: str, ground_truth: Optional[str] = None, ground_reasoning: Optional[str] = None
+        self,
+        example_id: str,
+        ground_truth: Optional[Union[str, dict]] = None,
+        ground_reasoning: Optional[str] = None,
     ) -> "AnnotateExampleResponse":
+        """Write a ground-truth annotation back to an example.
+
+        ``ground_truth`` should be a dict mapping output field name -> value
+        (e.g. ``{"verdict": "A>B"}``); this is the v2 format and uses the
+        /api/v2 annotate endpoint, matching ``predict``'s ``ground_truth``.
+
+        Passing a plain string is deprecated: it routes to the legacy /api/v1
+        endpoint and emits a ``DeprecationWarning``.
+        """
         annotation: PredictionAnnotation = {"arbiter_repo": self.repo}
         if ground_truth is not None:
             annotation["ground_truth"] = ground_truth
@@ -810,9 +823,26 @@ class ModaicClient:
             return PredictedExample.model_validate(response.json())
 
     def annotate_example(self, example_id: str, annotations: list[PredictionAnnotation]) -> AnnotateExampleResponse:
+        # v2 takes dict-based ``ground_truth`` (field_name -> value), matching
+        # the format used by predictions. A plain ``str`` ground_truth is the
+        # legacy v1 format: it routes to the deprecated /api/v1 endpoint and
+        # emits a DeprecationWarning. Calls that only touch ``ground_reasoning``
+        # (no ``ground_truth``) use v2.
+        legacy = any(isinstance(a.get("ground_truth"), str) for a in annotations)
+        if legacy:
+            warnings.warn(
+                "Annotating with a string `ground_truth` uses the deprecated "
+                "/api/v1/examples/{id}/annotation endpoint. Pass `ground_truth` "
+                "as a dict (output field name -> value) to use /api/v2 instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            path = f"/api/v1/examples/{example_id}/annotation"
+        else:
+            path = f"/api/v2/examples/{example_id}/annotation"
         with self.get_client() as client:
             response = client.patch(
-                f"/api/v1/examples/{example_id}/annotation",
+                path,
                 json={"annotations": annotations},
             )
             raise_errors(response)

--- a/src/modaic-client/modaic_client/schemas.py
+++ b/src/modaic-client/modaic_client/schemas.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Any, Literal, Optional, TypedDict
+from typing import Any, Literal, Optional, TypedDict, Union
 
 from pydantic import AliasChoices, BaseModel, Field, model_validator
 
@@ -40,8 +40,11 @@ class ExamplesPage(BaseModel):
 
 
 class PredictionAnnotation(TypedDict, total=False):
+    # ``ground_truth`` is a dict mapping output field name -> value (v2 format,
+    # routed to /api/v2). A plain ``str`` is the deprecated v1 format and routes
+    # to the legacy /api/v1 annotate endpoint.
     arbiter_repo: str
-    ground_truth: Optional[str]
+    ground_truth: Optional[Union[str, dict]]
     ground_reasoning: Optional[str]
 
 

--- a/tests/modaic_client/test_annotate_routing.py
+++ b/tests/modaic_client/test_annotate_routing.py
@@ -1,0 +1,75 @@
+# ruff: noqa: ANN001, ANN201
+"""Unit tests for ModaicClient.annotate_example v1/v2 endpoint routing.
+
+These run without a live server: ``get_client`` is patched to yield a mock
+httpx client so we can assert which path the PATCH targets.
+"""
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+from modaic_client.client import ModaicClient
+from modaic_client.schemas import AnnotateExampleResponse
+
+
+@pytest.fixture
+def client_and_http():
+    """A ModaicClient whose HTTP calls hit a mock returning ``status: success``."""
+    mock_http = MagicMock()
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"status": "success"}
+    mock_http.patch.return_value = resp
+
+    client = ModaicClient(modaic_token="test-token", base_url="http://test")
+
+    @contextmanager
+    def fake_get_client(access_token=None):
+        yield mock_http
+
+    client.get_client = fake_get_client
+    return client, mock_http
+
+
+def _patched_path(mock_http):
+    return mock_http.patch.call_args[0][0]
+
+
+def test_dict_ground_truth_uses_v2(client_and_http):
+    client, mock_http = client_and_http
+    result = client.annotate_example(
+        "ex-1",
+        [{"arbiter_repo": "u/r", "ground_truth": {"verdict": "A>B"}}],
+    )
+    assert _patched_path(mock_http) == "/api/v2/examples/ex-1/annotation"
+    assert isinstance(result, AnnotateExampleResponse)
+    assert result.status == "success"
+
+
+def test_reasoning_only_uses_v2(client_and_http):
+    client, mock_http = client_and_http
+    client.annotate_example("ex-2", [{"arbiter_repo": "u/r", "ground_reasoning": "because"}])
+    assert _patched_path(mock_http) == "/api/v2/examples/ex-2/annotation"
+
+
+def test_string_ground_truth_uses_v1_and_warns(client_and_http):
+    client, mock_http = client_and_http
+    with pytest.warns(DeprecationWarning, match="v1"):
+        client.annotate_example("ex-3", [{"arbiter_repo": "u/r", "ground_truth": "A>B"}])
+    assert _patched_path(mock_http) == "/api/v1/examples/ex-3/annotation"
+
+
+def test_dict_ground_truth_does_not_warn(client_and_http):
+    client, mock_http = client_and_http
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        client.annotate_example("ex-4", [{"arbiter_repo": "u/r", "ground_truth": {"k": "v"}}])
+
+
+def test_body_passes_annotations_through(client_and_http):
+    client, mock_http = client_and_http
+    annotations = [{"arbiter_repo": "u/r", "ground_truth": {"verdict": "A>B"}, "ground_reasoning": "r"}]
+    client.annotate_example("ex-5", annotations)
+    assert mock_http.patch.call_args.kwargs["json"] == {"annotations": annotations}

--- a/tests/modaic_client/test_arbiter.py
+++ b/tests/modaic_client/test_arbiter.py
@@ -162,7 +162,19 @@ def test_get_example_delegates_to_client(arbiter, mock_client):
 # ── annotate_example ─────────────────────────────────────────────────
 
 
+def test_annotate_example_with_dict_ground_truth(arbiter, mock_client):
+    # v2 format: ground_truth is a dict keyed by output field name.
+    arbiter.annotate_example("ex-123", ground_truth={"verdict": "A"}, ground_reasoning="reason")
+
+    mock_client.annotate_example.assert_called_once_with(
+        "ex-123",
+        [{"arbiter_repo": "testuser/testrepo", "ground_truth": {"verdict": "A"}, "ground_reasoning": "reason"}],
+    )
+
+
 def test_annotate_example_with_both_fields(arbiter, mock_client):
+    # Legacy string ground_truth still passes through the wrapper unchanged
+    # (the v1 deprecation warning is emitted by ModaicClient, mocked here).
     arbiter.annotate_example("ex-123", ground_truth="A", ground_reasoning="reason")
 
     mock_client.annotate_example.assert_called_once_with(

--- a/tests/modaic_client/test_modaic_client.py
+++ b/tests/modaic_client/test_modaic_client.py
@@ -203,10 +203,20 @@ class TestGetExampleIntegration:
 @requires_token
 class TestAnnotateExampleIntegration:
     def test_annotate_returns_success(self, client, arbiter, ingested_example_ids):
+        # v2: dict-based ground_truth (output field name -> value).
         resp = client.annotate_example(
             ingested_example_ids[1],
-            [{"arbiter_repo": arbiter.repo, "ground_truth": "4", "ground_reasoning": "simple math"}],
+            [{"arbiter_repo": arbiter.repo, "ground_truth": {"answer": "4"}, "ground_reasoning": "simple math"}],
         )
+        assert isinstance(resp, AnnotateExampleResponse)
+
+    def test_annotate_string_ground_truth_is_deprecated(self, client, arbiter, ingested_example_ids):
+        # Legacy string ground_truth still works via the deprecated v1 endpoint.
+        with pytest.warns(DeprecationWarning):
+            resp = client.annotate_example(
+                ingested_example_ids[1],
+                [{"arbiter_repo": arbiter.repo, "ground_truth": "4", "ground_reasoning": "simple math"}],
+            )
         assert isinstance(resp, AnnotateExampleResponse)
 
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -327,7 +327,7 @@ def test_annotate_example(client, ingested_ids):  # noqa
         [
             {
                 "arbiter_repo": TEST_REPO,
-                "ground_truth": "A>B",
+                "ground_truth": {"verdict": "A>B"},
                 "ground_reasoning": "Response A correctly computes 2+2=4. Response B references a novel, not math.",
             },
         ],
@@ -337,7 +337,8 @@ def test_annotate_example(client, ingested_ids):  # noqa
     assert result.status == "success"
 
     updated = client.get_example(example_id)
-    assert updated.ground_truth == "A>B"
+    # v2 stores the dict ground_truth JSON-serialized in the legacy column.
+    assert json.loads(updated.ground_truth) == {"verdict": "A>B"}
     assert "correctly computes" in updated.ground_reasoning
 
 
@@ -346,12 +347,27 @@ def test_annotate_example_via_arbiter(arbiter, ingested_ids):  # noqa
 
     result = arbiter.annotate_example(
         example_id,
-        ground_truth="A>B",
+        ground_truth={"verdict": "A>B"},
         ground_reasoning="Shakespeare is the universally accepted author of Hamlet.",
     )
     assert result.status == "success"
 
     updated = arbiter.get_example(example_id)
+    assert json.loads(updated.ground_truth) == {"verdict": "A>B"}
+
+
+def test_annotate_example_string_ground_truth_deprecated(client, ingested_ids):  # noqa
+    """A string ground_truth still works but routes to the deprecated v1 endpoint."""
+    example_id = ingested_ids[2]
+    with pytest.warns(DeprecationWarning):
+        result = client.annotate_example(
+            example_id,
+            [{"arbiter_repo": TEST_REPO, "ground_truth": "A>B"}],
+        )
+    assert result.status == "success"
+
+    updated = client.get_example(example_id)
+    # v1 stores the raw string ground_truth.
     assert updated.ground_truth == "A>B"
 
 
@@ -359,6 +375,6 @@ def test_annotate_nonexistent_example(client):  # noqa
     with pytest.raises(httpx.HTTPStatusError) as exc_info:
         client.annotate_example(
             "00000000-0000-0000-0000-000000000000",
-            [{"arbiter_repo": TEST_REPO, "ground_truth": "A>B"}],
+            [{"arbiter_repo": TEST_REPO, "ground_truth": {"verdict": "A>B"}}],
         )
     assert exc_info.value.response.status_code == 404


### PR DESCRIPTION
## What

The SDK's annotate path was the **lone v1 holdover**. `Arbiter.predict` / `ModaicClient.predict` already use `/api/v2/arbiters/predictions` with a **dict** `ground_truth`, but `annotate_example` still hit:

```
PATCH /api/v1/examples/{example_id}/annotation   # ground_truth: str
```

This switches the client SDK's annotate to the **v2 endpoint** and deprecates v1.

## Behavior

`ModaicClient.annotate_example` now picks the endpoint by `ground_truth` type:

| `ground_truth`                | Endpoint                                   | Notes |
|-------------------------------|--------------------------------------------|-------|
| `dict` (e.g. `{"verdict": "A>B"}`) | `PATCH /api/v2/examples/{id}/annotation` | new default — matches `predict` + batch predictions |
| `str` (e.g. `"A>B"`)          | `PATCH /api/v1/examples/{id}/annotation`   | **deprecated** → emits `DeprecationWarning` |
| reasoning-only (no `ground_truth`) | `PATCH /api/v2/...`                    | |

v2 takes a dict mapping **output field name → value** and JSON-serializes it into the legacy `ground_truth` column server-side (see `modaic-dev` `server/src/api/v2/examples/index.py`).

## Changes

- `ModaicClient.annotate_example`: route v1 vs v2 by `ground_truth` type; warn on the legacy string path.
- `Arbiter.annotate_example`: accept `ground_truth: Optional[Union[str, dict]]` (was `str`), with a docstring steering callers to the dict form.
- `PredictionAnnotation.ground_truth`: widen to `Optional[Union[str, dict]]`.
- Tests: new runnable unit tests for endpoint routing + the deprecation warning (`tests/modaic_client/test_annotate_routing.py`); updated integration tests to the v2 dict format and added v1-deprecation coverage.

## Backward compatibility

Non-breaking. Existing callers passing a string `ground_truth` (e.g. `mo_buzz`) keep working — they just get a `DeprecationWarning` nudging them to the dict form. Migrate by wrapping the value in a dict keyed by the arbiter's output field, e.g. `ground_truth={"verdict": "skip"}`.

## Scope

Only the **annotate** endpoint has a v2 counterpart in the server today (`/api/v2/examples` exposes just `PATCH .../annotation`); the other v1 examples endpoints — `ingest_examples`, `list_examples`, `get_example` — have no v2 equivalent yet, so they are intentionally left on v1.

## Notes

- `tests/modaic_client/test_arbiter.py::test_predict_delegates_to_client` fails on `main` already (pre-existing `compute_confidence` mismatch, unrelated to this change) and is left untouched.
- The annotate integration tests require `MODAIC_TOKEN` + a live server running the v2 endpoint; the new routing unit tests run without either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)