### PR TITLE
fix(hub): close and serialize Git snapshot resources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "modaic-client",
     "rich>=14.1.0",
     "pytest-asyncio>=1.3.0",
+    "psutil>=6.1.1",
     "torch>=2.10.0",
     "openai>=1.0.0",
     "anthropic>=0.40.0",

--- a/src/modaic-sdk/modaic/hub.py
+++ b/src/modaic-sdk/modaic/hub.py
@@ -1,3 +1,4 @@
+import hashlib
 import re
 import shutil
 import subprocess
@@ -10,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, Literal, Optional, Tuple, Union
 
 import git
 from dotenv import find_dotenv, load_dotenv
+from filelock import FileLock
 from git.repo.fun import BadName, BadObject, name_to_object
 from modaic_client import get_modaic_client, settings
 from modaic_client.exceptions import (
@@ -284,70 +286,84 @@ def git_snapshot(
     if access_token is None and settings.modaic_token is not None:
         access_token = settings.modaic_token
 
-    program_dir = Path(settings.modaic_hub_cache) / repo_path
+    hub_cache = Path(settings.modaic_hub_cache)
+    program_dir = hub_cache / repo_path
     main_dir = program_dir / "main"
+    lock_digest = hashlib.sha256(repo_path.encode()).hexdigest()
+    lock_path = hub_cache / ".locks" / f"{lock_digest}.lock"
 
-    try:
-        main_dir.parent.mkdir(parents=True, exist_ok=True)
-        remote_url = _make_git_url(repo_path, access_token)
-
-        # Ensure we have a main checkout at program_dir/main
-        if not (main_dir / ".git").exists():
-            shutil.rmtree(main_dir, ignore_errors=True)
-            git.Repo.clone_from(remote_url, main_dir, multi_options=["--branch", "main"])
-
-        # Attatch origin
-        main_repo = git.Repo(main_dir)
-        if "origin" not in [r.name for r in main_repo.remotes]:
-            main_repo.create_remote("origin", remote_url)
-        else:
-            main_repo.remotes.origin.set_url(remote_url)
-
-        main_repo.remotes.origin.fetch()
-
-        revision = resolve_revision(main_repo, rev)
-
-        if revision.type == "commit" or revision.type == "tag":
-            rev_dir = program_dir / revision.sha
-
-            if not rev_dir.exists():
-                main_repo.git.worktree("add", str(rev_dir.resolve()), revision.sha)
-
-            shortcut_dir = program_dir / revision.name
-            shortcut_dir.unlink(missing_ok=True)
-            smart_link(shortcut_dir, rev_dir)
-
-        elif revision.type == "branch":
-            rev_dir = program_dir / revision.name
-
-            if not rev_dir.exists():
-                main_repo.git.worktree("add", str(rev_dir.resolve()), f"origin/{revision.name}")
-            else:
-                repo = git.Repo(rev_dir)
-                # No history merging: our hub checkouts are always expected to already be in
-                # sync with the hub (commits and pushes are atomic in our workflow). Hard-reset
-                # the cached worktree to origin instead of pulling, which avoids the "Need to
-                # specify how to reconcile divergent branches" failure and is purely local
-                # (origin/<branch> was already refreshed by the fetch above), so no extra
-                # network round-trip is added on this potentially hot reload path.
-                repo.git.reset("--hard", f"origin/{revision.name}")
-
-            # get the up to date sha for the branch
-            revision = resolve_revision(main_repo, f"origin/{revision.name}")
-
-        return rev_dir, Commit(repo_path, revision.sha)
-
-    except Exception as e:
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with FileLock(lock_path):
         try:
-            aggresive_rmtree(program_dir)
-        except Exception:
-            raise ModaicError(
-                f"Failed to cleanup settings.modaic_cache after a failed operation. We recommend manually deleting your modaic cache as it may be corrupted. Your cache is located at {settings.modaic_cache}"
-            ) from e
-        if isinstance(e, git.exc.GitCommandError):
-            if "remote: Not found." in e.stderr or "remote: Repository not found" in e.stderr:
-                raise RepositoryNotFoundError(f"Repository '{repo_path}' does not exist") from None
-        raise e
+            main_dir.parent.mkdir(parents=True, exist_ok=True)
+            remote_url = _make_git_url(repo_path, access_token)
+
+            # Ensure we have a main checkout at program_dir/main. GitPython starts
+            # persistent ``git cat-file`` helpers lazily; close every Repo explicitly
+            # instead of relying on cyclic GC to reap them in long-lived workers.
+            if not (main_dir / ".git").exists():
+                shutil.rmtree(main_dir, ignore_errors=True)
+                cloned_repo = git.Repo.clone_from(remote_url, main_dir, multi_options=["--branch", "main"])
+                cloned_repo.close()
+
+            main_repo = git.Repo(main_dir)
+            try:
+                if "origin" not in [r.name for r in main_repo.remotes]:
+                    main_repo.create_remote("origin", remote_url)
+                else:
+                    main_repo.remotes.origin.set_url(remote_url)
+
+                # Refresh remote refs once for the entire snapshot operation.
+                main_repo.remotes.origin.fetch()
+
+                revision = resolve_revision(main_repo, rev)
+
+                if revision.type == "commit" or revision.type == "tag":
+                    rev_dir = program_dir / revision.sha
+
+                    if not rev_dir.exists():
+                        main_repo.git.worktree("add", str(rev_dir.resolve()), revision.sha)
+
+                    shortcut_dir = program_dir / revision.name
+                    shortcut_dir.unlink(missing_ok=True)
+                    smart_link(shortcut_dir, rev_dir)
+
+                elif revision.type == "branch":
+                    rev_dir = program_dir / revision.name
+
+                    if not rev_dir.exists():
+                        main_repo.git.worktree("add", str(rev_dir.resolve()), f"origin/{revision.name}")
+                    else:
+                        repo = git.Repo(rev_dir)
+                        try:
+                            # No history merging: our hub checkouts are always expected to already be in
+                            # sync with the hub (commits and pushes are atomic in our workflow). Hard-reset
+                            # the cached worktree to origin instead of pulling, which avoids the "Need to
+                            # specify how to reconcile divergent branches" failure and is purely local
+                            # (origin/<branch> was already refreshed by the fetch above), so no extra
+                            # network round-trip is added on this potentially hot reload path.
+                            repo.git.reset("--hard", f"origin/{revision.name}")
+                        finally:
+                            repo.close()
+
+                    # Get the up-to-date SHA from the refs refreshed above.
+                    revision = resolve_revision(main_repo, f"origin/{revision.name}")
+
+                return rev_dir, Commit(repo_path, revision.sha)
+            finally:
+                main_repo.close()
+
+        except Exception as e:
+            try:
+                aggresive_rmtree(program_dir)
+            except Exception:
+                raise ModaicError(
+                    f"Failed to cleanup settings.modaic_cache after a failed operation. We recommend manually deleting your modaic cache as it may be corrupted. Your cache is located at {settings.modaic_cache}"
+                ) from e
+            if isinstance(e, git.exc.GitCommandError):
+                if "remote: Not found." in e.stderr or "remote: Repository not found" in e.stderr:
+                    raise RepositoryNotFoundError(f"Repository '{repo_path}' does not exist") from None
+            raise e
 
 
 def _move_to_commit_sha_folder(repo: git.Repo) -> git.Repo:
@@ -395,7 +411,9 @@ class Revision:
 
 def resolve_revision(repo: git.Repo, rev: str) -> Revision:
     """
-    Resolves the revision to a branch, tag, or commit SHA.
+    Resolves the revision to a branch, tag, or commit SHA using local refs.
+
+    Callers that need remote freshness must fetch before invoking this helper.
     Args:
         repo: The git.Repo object.
         rev: The revision to resolve.
@@ -419,8 +437,6 @@ def resolve_revision(repo: git.Repo, rev: str) -> Revision:
         >>> resolve_revision(repo, "1234567890")
         Revision(type="commit", name="<sha>", sha="<sha>")
     """
-    repo.remotes.origin.fetch()
-
     # Fast validation of rev; if not found, try origin/<rev> for branches existing only on remote
     try:
         ref = repo.rev_parse(rev)

--- a/src/modaic-sdk/pyproject.toml
+++ b/src/modaic-sdk/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "dspy>=3.3.0,<4",
     "litellm>=1.80.8",
     "gitpython>=3.1.45",
+    "filelock>=3.18.0",
     "safetensors>=0.7.0",
     "tomlkit>=0.13.3",
     "python-frontmatter>=1.1.0",

--- a/tests/test_hub_git.py
+++ b/tests/test_hub_git.py
@@ -1,17 +1,24 @@
-"""Pure-git regression tests for hub.git_snapshot's branch-reload strategy.
+"""Pure-git regression tests for hub.git_snapshot.
 
 These tests do not touch the Modaic hub (no MODAIC_TOKEN required). They lock in
 the decision to hard-reset cached branch worktrees to ``origin/<branch>`` instead
 of running ``git pull``. ``git pull`` fails with
 "fatal: Need to specify how to reconcile divergent branches." when the cached
 checkout has diverged from origin (observed in production); a hard reset recovers
-cleanly because our hub checkouts are always expected to already be in sync.
+cleanly because our hub checkouts are always expected to already be in sync. They
+also verify that repeated and concurrent snapshots do not leak Git helpers or
+race while creating the shared cache.
 """
 
+import gc
+import multiprocessing
+from multiprocessing.queues import Queue
 from pathlib import Path
 
 import git
+import psutil
 import pytest
+from modaic import hub
 
 
 def _commit_file(repo: git.Repo, path: Path, content: str, message: str) -> None:
@@ -26,6 +33,42 @@ def _init_repo(path: Path, bare: bool = False) -> git.Repo:
         repo.git.config("user.email", "test@modaic.dev")
         repo.git.config("user.name", "modaic-test")
     return repo
+
+
+def _seed_remote(tmp_path: Path) -> Path:
+    bare_path = tmp_path / "remote.git"
+    bare = _init_repo(bare_path, bare=True)
+    seed_path = tmp_path / "seed"
+    seed = _init_repo(seed_path)
+    try:
+        _commit_file(seed, seed_path / "program.py", "VALUE = 1\n", "init")
+        seed.create_remote("origin", str(bare_path))
+        seed.remotes.origin.push("HEAD:refs/heads/main")
+    finally:
+        seed.close()
+        bare.close()
+    return bare_path
+
+
+def _git_cat_file_children() -> set[int]:
+    helpers: set[int] = set()
+    for child in psutil.Process().children(recursive=True):
+        try:
+            if "git cat-file" in " ".join(child.cmdline()):
+                helpers.add(child.pid)
+        except (psutil.AccessDenied, psutil.NoSuchProcess, psutil.ZombieProcess):
+            continue
+    return helpers
+
+
+def _snapshot_in_process(cache_path: str, remote_path: str, result_queue: Queue) -> None:
+    hub.settings.modaic_cache = cache_path
+    hub._make_git_url = lambda _repo_path, _access_token: remote_path
+    try:
+        snapshot_path, commit = hub.git_snapshot("owner/program", access_token="test-token")
+        result_queue.put((str(snapshot_path), commit.sha, None))
+    except Exception as exc:  # pragma: no cover - surfaced to the parent assertion
+        result_queue.put((None, None, repr(exc)))
 
 
 def test_hard_reset_recovers_where_pull_fails_on_divergence(tmp_path: Path):
@@ -89,3 +132,96 @@ def test_hard_reset_is_noop_when_already_in_sync(tmp_path: Path):
     assert cache.head.commit.hexsha == before
     assert (tmp_path / "cache" / "a.txt").read_text() == "v1"
     assert not cache.is_dirty()
+
+
+def test_repeated_snapshots_close_git_helpers_without_gc(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    remote = _seed_remote(tmp_path)
+    cache_root = tmp_path / "cache"
+    cache = cache_root / "modaic_hub/modaic_hub"
+    monkeypatch.setattr(hub.settings, "modaic_cache", str(cache_root))
+    monkeypatch.setattr(hub, "_make_git_url", lambda _repo_path, _access_token: str(remote))
+    original_fetch = git.Remote.fetch
+    fetch_count = 0
+
+    def counting_fetch(remote_obj: git.Remote, *args, **kwargs):
+        nonlocal fetch_count
+        fetch_count += 1
+        return original_fetch(remote_obj, *args, **kwargs)
+
+    monkeypatch.setattr(git.Remote, "fetch", counting_fetch)
+
+    gc.collect()
+    helpers_before = _git_cat_file_children()
+    gc_was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        for _ in range(50):
+            snapshot_path, commit = hub.git_snapshot("owner/program", access_token="test-token")
+            assert snapshot_path == cache / "owner/program/main"
+            assert commit.sha
+    finally:
+        if gc_was_enabled:
+            gc.enable()
+
+    assert _git_cat_file_children() == helpers_before
+    assert fetch_count == 50
+
+
+def test_concurrent_processes_share_one_valid_snapshot(tmp_path: Path):
+    remote = _seed_remote(tmp_path)
+    cache_root = tmp_path / "cache"
+    cache = cache_root / "modaic_hub/modaic_hub"
+    ctx = multiprocessing.get_context("spawn")
+    result_queue = ctx.Queue()
+    processes = [
+        ctx.Process(target=_snapshot_in_process, args=(str(cache_root), str(remote), result_queue)) for _ in range(4)
+    ]
+
+    for process in processes:
+        process.start()
+    results = [result_queue.get(timeout=30) for _ in processes]
+    for process in processes:
+        process.join(timeout=30)
+        assert process.exitcode == 0
+
+    errors = [error for _path, _sha, error in results if error]
+    assert errors == []
+    assert len({path for path, _sha, _error in results}) == 1
+    assert len({sha for _path, sha, _error in results}) == 1
+
+    snapshot = git.Repo(cache / "owner/program/main")
+    try:
+        assert snapshot.head.commit.hexsha == results[0][1]
+        assert (cache / "owner/program/main/program.py").read_text() == "VALUE = 1\n"
+    finally:
+        snapshot.close()
+
+
+def test_snapshot_failure_releases_lock_outside_cleaned_cache(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    remote = _seed_remote(tmp_path)
+    cache_root = tmp_path / "cache"
+    cache = cache_root / "modaic_hub/modaic_hub"
+    monkeypatch.setattr(hub.settings, "modaic_cache", str(cache_root))
+    monkeypatch.setattr(hub, "_make_git_url", lambda _repo_path, _access_token: str(remote))
+
+    original_clone = git.Repo.clone_from
+    attempts = 0
+
+    def fail_once(*args, **kwargs):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise RuntimeError("synthetic clone failure")
+        return original_clone(*args, **kwargs)
+
+    monkeypatch.setattr(git.Repo, "clone_from", fail_once)
+
+    with pytest.raises(RuntimeError, match="synthetic clone failure"):
+        hub.git_snapshot("owner/program", access_token="test-token")
+
+    snapshot_path, commit = hub.git_snapshot("owner/program", access_token="test-token")
+    assert snapshot_path.exists()
+    assert commit.sha
+    assert len(list((cache / ".locks").glob("*.lock"))) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13' and sys_platform == 'win32'",
@@ -38,6 +38,7 @@ dev = [
     { name = "modal", specifier = ">=1.3.5" },
     { name = "openai", specifier = ">=1.0.0" },
     { name = "pandas", specifier = ">=2.3.3" },
+    { name = "psutil", specifier = ">=6.1.1" },
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "python-dotenv", specifier = ">=1.1.1" },
@@ -2678,6 +2679,7 @@ name = "modaic"
 source = { editable = "src/modaic-sdk" }
 dependencies = [
     { name = "dspy" },
+    { name = "filelock" },
     { name = "gitpython" },
     { name = "litellm" },
     { name = "modaic-client" },
@@ -2758,6 +2760,7 @@ requires-dist = [
     { name = "duckdb", marker = "extra == 'openai'", specifier = ">=1.2.0" },
     { name = "duckdb", marker = "extra == 'together'", specifier = ">=1.2.0" },
     { name = "duckdb", marker = "extra == 'vllm'", specifier = ">=1.2.0" },
+    { name = "filelock", specifier = ">=3.18.0" },
     { name = "gitpython", specifier = ">=3.1.45" },
     { name = "hf-transfer", marker = "extra == 'batch'" },
     { name = "hf-transfer", marker = "extra == 'vllm'" },


### PR DESCRIPTION
## Summary
- explicitly close GitPython repositories used by `git_snapshot` so persistent Git helpers are reaped immediately
- serialize cache mutation per repository with a cache-external file lock
- fetch remote refs once per snapshot instead of up to three times

## Production failure
Long-lived Celery workers repeatedly loaded arbiters through `Predict.from_precompiled`. Git helper processes survived until cyclic GC, and concurrent workers raced over the same cache. The worker container eventually exhausted its PID cgroup and Python raised `RuntimeError: can't start new thread`.

## Tests
- `uv run ruff check src/modaic-sdk/modaic/hub.py tests/test_hub_git.py`
- `uv run pytest tests/test_hub_git.py -q` (5 passed)
- regression coverage disables GC across 50 snapshots, asserts one fetch per call and zero leaked `git cat-file` helpers, exercises four spawned processes, and verifies lock release after failure

The broader repository run reached 202 passing tests; remaining integration tests require the local API service configured by that suite and one pre-existing client mock expectation is stale.